### PR TITLE
[#13] OpenAI 자동 태깅 저장

### DIFF
--- a/src/main/java/org/project/soar/config/SecurityConfig.java
+++ b/src/main/java/org/project/soar/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             "/swagger-resources/**",
             "/v3/api-docs.yaml",
-            "/api/field/", "api/tag/","/api/youth-policy","/api/youth-policy/sync","api/chatgpt/promptManagement",
+            "/api/field/", "api/tag/","/api/youth-policy","/api/youth-policy/sync","api/chatgpt/promptManagement","/api/youthPolicyTag/",
             "/api/youth-policy/**"
     };
 

--- a/src/main/java/org/project/soar/model/tag/YouthPolicyTag.java
+++ b/src/main/java/org/project/soar/model/tag/YouthPolicyTag.java
@@ -30,4 +30,11 @@ public class YouthPolicyTag {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "field_id", nullable = false)
     private Field field;
+
+    @Builder
+    public YouthPolicyTag(YouthPolicy youthPolicy, Tag tag, Field field) {
+        this.youthPolicy = youthPolicy;
+        this.tag = tag;
+        this.field = field;
+    }
 }

--- a/src/main/java/org/project/soar/model/tag/controller/ChatGPTController.java
+++ b/src/main/java/org/project/soar/model/tag/controller/ChatGPTController.java
@@ -52,8 +52,11 @@ public class ChatGPTController {
     chatGPT Prompt Management(프롬프트 튜닝 태깅)
      **/
     @PostMapping("/promptManagement")
-    public ResponseEntity<ApiResponse<List<Map<String, Object>>>> runPrompt() {
-        List<Map<String, Object>> result = chatGPTService.runPrompt();
+    public ResponseEntity<ApiResponse<List<YouthPolicyTag>>> runPrompt() {
+        List<YouthPolicyTag> result = chatGPTService.runPrompt();
+        if (result.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body((ApiResponse<List<YouthPolicyTag>>) ApiResponse.createError("empty"));
+        }
         return ResponseEntity.ok(ApiResponse.createSuccess(result));
     }
 }

--- a/src/main/java/org/project/soar/model/tag/controller/ChatGPTController.java
+++ b/src/main/java/org/project/soar/model/tag/controller/ChatGPTController.java
@@ -1,9 +1,13 @@
 package org.project.soar.model.tag.controller;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.project.soar.global.api.ApiResponse;
+import org.project.soar.model.tag.YouthPolicyTag;
 import org.project.soar.model.tag.dto.ChatCompletion;
 import org.project.soar.model.tag.service.ChatGPTService;
+import org.project.soar.model.user.dto.SignUpResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,14 +16,12 @@ import java.util.Map;
 
 @Slf4j
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/chatgpt")
 public class ChatGPTController {
 
     private final ChatGPTService chatGPTService;
 
-    public ChatGPTController(ChatGPTService chatGPTService) {
-        this.chatGPTService = chatGPTService;
-    }
     /**
     chatGPT 모델리스트 조회
      **/

--- a/src/main/java/org/project/soar/model/tag/controller/YouthPolicyTagController.java
+++ b/src/main/java/org/project/soar/model/tag/controller/YouthPolicyTagController.java
@@ -1,0 +1,26 @@
+package org.project.soar.model.tag.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.project.soar.global.api.ApiResponse;
+import org.project.soar.model.tag.dto.YouthPolicyTagResponse;
+import org.project.soar.model.tag.service.YouthPolicyTagService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/youthPolicyTag")
+public class YouthPolicyTagController {
+    public final YouthPolicyTagService youthPolicyTagService;
+    @GetMapping("/")
+    public ResponseEntity<ApiResponse<List<YouthPolicyTagResponse>>> getAllYouthPolicyTag() {
+        ApiResponse<List<YouthPolicyTagResponse>> response = ApiResponse.createSuccess(youthPolicyTagService.getAllYouthPolicyTag());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/project/soar/model/tag/dto/YouthPolicyTagResponse.java
+++ b/src/main/java/org/project/soar/model/tag/dto/YouthPolicyTagResponse.java
@@ -2,7 +2,11 @@ package org.project.soar.model.tag.dto;
 
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
 @Data
 public class YouthPolicyTagResponse {
     private String policyId;

--- a/src/main/java/org/project/soar/model/tag/repository/TagRepository.java
+++ b/src/main/java/org/project/soar/model/tag/repository/TagRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TagRepository extends JpaRepository<Tag, Long> {
+    Tag findByTagId(Long tagId);
 }

--- a/src/main/java/org/project/soar/model/tag/repository/YouthPolicyTagRepository.java
+++ b/src/main/java/org/project/soar/model/tag/repository/YouthPolicyTagRepository.java
@@ -1,7 +1,13 @@
 package org.project.soar.model.tag.repository;
 
 import org.project.soar.model.tag.YouthPolicyTag;
+import org.project.soar.model.youthpolicy.YouthPolicy;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+
+@Repository
 public interface YouthPolicyTagRepository extends JpaRepository<YouthPolicyTag, Long> {
+
+    boolean existsByYouthPolicy(YouthPolicy youthPolicy);
 }

--- a/src/main/java/org/project/soar/model/tag/service/ChatGPTService.java
+++ b/src/main/java/org/project/soar/model/tag/service/ChatGPTService.java
@@ -1,5 +1,6 @@
 package org.project.soar.model.tag.service;
 
+import org.project.soar.model.tag.YouthPolicyTag;
 import org.project.soar.model.tag.dto.ChatCompletion;
 import org.springframework.stereotype.Service;
 
@@ -12,5 +13,5 @@ public interface ChatGPTService {
     Map<String, Object> isValidModel(String modelName);
     Map<String, Object> prompt(ChatCompletion chatCompletion);
 
-    List<Map<String, Object>> runPrompt();
+    List<YouthPolicyTag> runPrompt();
 }

--- a/src/main/java/org/project/soar/model/tag/service/YouthPolicyTagService.java
+++ b/src/main/java/org/project/soar/model/tag/service/YouthPolicyTagService.java
@@ -2,10 +2,11 @@ package org.project.soar.model.tag.service;
 
 import org.project.soar.model.tag.YouthPolicyTag;
 import org.project.soar.model.tag.dto.YouthPolicyTagResponse;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
-
+@Service
 public interface YouthPolicyTagService {
     public List<YouthPolicyTagResponse> getAllYouthPolicyTag();
-    public YouthPolicyTag setYouthPolicyTag();
+    public YouthPolicyTag setYouthPolicyTag(YouthPolicyTagResponse youthPolicyTagResponse);
 }

--- a/src/main/java/org/project/soar/model/tag/service/YouthPolicyTagServiceImpl.java
+++ b/src/main/java/org/project/soar/model/tag/service/YouthPolicyTagServiceImpl.java
@@ -1,9 +1,14 @@
 package org.project.soar.model.tag.service;
 
 import lombok.RequiredArgsConstructor;
+import org.project.soar.model.field.Field;
+import org.project.soar.model.tag.Tag;
 import org.project.soar.model.tag.YouthPolicyTag;
 import org.project.soar.model.tag.dto.YouthPolicyTagResponse;
+import org.project.soar.model.tag.repository.TagRepository;
 import org.project.soar.model.tag.repository.YouthPolicyTagRepository;
+import org.project.soar.model.youthpolicy.YouthPolicy;
+import org.project.soar.model.youthpolicy.repository.YouthPolicyRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -12,8 +17,9 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class YouthPolicyTagServiceImpl implements YouthPolicyTagService{
-
-    YouthPolicyTagRepository youthPolicyTagRepository;
+    public final YouthPolicyRepository youthPolicyRepository;
+    public final TagRepository tagRepository;
+    public final YouthPolicyTagRepository youthPolicyTagRepository;
     @Override
     public List<YouthPolicyTagResponse> getAllYouthPolicyTag() {
         List<YouthPolicyTagResponse> result =
@@ -26,8 +32,12 @@ public class YouthPolicyTagServiceImpl implements YouthPolicyTagService{
     }
 
     @Override
-    public YouthPolicyTag setYouthPolicyTag() {
-        //TODO : 지피티에서 얻어온 태그 이걸로 넣기
-        return null;
+    public YouthPolicyTag setYouthPolicyTag(YouthPolicyTagResponse youthPolicyTag) {
+        YouthPolicy myYouthPolicy = youthPolicyRepository.findByPolicyId(youthPolicyTag.getPolicyId());
+        Tag myTag = tagRepository.findByTagId(youthPolicyTag.getTagId());
+        Field myField = myTag.getField();
+        YouthPolicyTag newYouthPolicyTag = new YouthPolicyTag(myYouthPolicy, myTag, myField);
+        youthPolicyTagRepository.save(newYouthPolicyTag);
+        return newYouthPolicyTag;
     }
 }

--- a/src/main/java/org/project/soar/model/youthpolicy/repository/YouthPolicyRepository.java
+++ b/src/main/java/org/project/soar/model/youthpolicy/repository/YouthPolicyRepository.java
@@ -27,6 +27,11 @@ public interface YouthPolicyRepository extends JpaRepository<YouthPolicy, String
     List<YouthPolicy> searchByKeyword(@Param("keyword") String keyword);
 
     /**
+     * 정책아이디로 검색
+     */
+    YouthPolicy findByPolicyId(String policyId);
+
+    /**
      * 대분류로 검색 (카테고리 검색용)
      */
     List<YouthPolicy> findByLargeClassificationContaining(String category);
@@ -225,5 +230,7 @@ public interface YouthPolicyRepository extends JpaRepository<YouthPolicy, String
     List<YouthPolicy> findByCreatedAtYearAndMonth(@Param("year") int year, @Param("month") int month);
 
     List<YouthPolicy> findTop2ByOrderByCreatedAtDesc();
+
+    List<YouthPolicy> findTop5ByOrderByCreatedAtDesc();
 }
 


### PR DESCRIPTION
OpenAI 자동 태깅 로직

ChatGPTController 호출
-> ChatGPTService 호출 
-> youthPolicyRepository에서 정책 조회
-> YouthPolicyTagRepository에 이미 존재하는 정책인지 확인
-> 존재하지 않으면 Tag 생성
-> youthPolicyTagService 호출
-> youthPolicyTagRepository에 저장