### PR TITLE
[#21] userId로 정책 조회 구현

### DIFF
--- a/src/main/java/org/project/soar/config/SecurityConfig.java
+++ b/src/main/java/org/project/soar/config/SecurityConfig.java
@@ -35,8 +35,8 @@ public class SecurityConfig {
             "/v3/api-docs.yaml",
             "/api/field/", "/api/tag/",
             "/api/user-tag/", "/api/user-tag/**", "/api/user-tag/all",
-            "/api/youth-policy","/api/youth-policy/sync","/api/youth-policy/**",
-            "/api/youth-policy-tag/", "/api/youth-policy-tag/tag",
+            "/api/youth-policy","/api/youth-policy/sync","/api/youth-policy/**","/api/auth/match-policies",
+            "/api/youth-policy-tag/", "/api/youth-policy-tag/tag", "/api/youth-policy-tag/tags",
             "api/chatgpt/promptManagement",
             "/api/banner/**"
     };

--- a/src/main/java/org/project/soar/config/TokenProvider.java
+++ b/src/main/java/org/project/soar/config/TokenProvider.java
@@ -9,7 +9,6 @@ import org.project.soar.model.user.repository.RefreshTokenRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,7 +23,6 @@ import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
 
-@PropertySource("classpath:jwt.yml")
 @Service
 public class TokenProvider {
     private final String secretKey;

--- a/src/main/java/org/project/soar/model/tag/dto/YouthPolicyTagsResponse.java
+++ b/src/main/java/org/project/soar/model/tag/dto/YouthPolicyTagsResponse.java
@@ -1,0 +1,24 @@
+package org.project.soar.model.tag.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import org.project.soar.model.tag.Tag;
+import org.project.soar.model.youthpolicy.YouthPolicy;
+
+import java.util.List;
+
+@Data
+@Getter
+@Setter
+public class YouthPolicyTagsResponse {
+    private List<Tag> tags;
+    private List<YouthPolicy> YouthPolicies;
+
+    @Builder
+    public YouthPolicyTagsResponse(List<Tag> tags, List<YouthPolicy> YouthPolicies) {
+        this.tags = tags;
+        this.YouthPolicies = YouthPolicies;
+    }
+}

--- a/src/main/java/org/project/soar/model/user/controller/UserController.java
+++ b/src/main/java/org/project/soar/model/user/controller/UserController.java
@@ -234,4 +234,9 @@ public class UserController {
                     .body(ApiResponse.createError("카카오 회원 탈퇴 실패: " + e.getMessage()));
         }
     }
+    @PostMapping("/match-policies")
+    public ResponseEntity<ApiResponse<MatchYouthPoliciesResponse>> findMatchPolicies(@RequestParam("userId") Long userId) {
+        MatchYouthPoliciesResponse result = userService.getMatchPolicies(userId);
+        return ResponseEntity.ok(ApiResponse.createSuccess(result));
+    }
 }

--- a/src/main/java/org/project/soar/model/user/dto/MatchYouthPoliciesResponse.java
+++ b/src/main/java/org/project/soar/model/user/dto/MatchYouthPoliciesResponse.java
@@ -1,0 +1,27 @@
+package org.project.soar.model.user.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import org.project.soar.model.tag.Tag;
+import org.project.soar.model.youthpolicy.YouthPolicy;
+
+import java.util.List;
+
+@Data
+@Getter
+@Setter
+public class MatchYouthPoliciesResponse {
+    Long userId;
+    List<Tag> tags;
+    List<YouthPolicy> youthPolicyTags;
+
+    @Builder
+    public MatchYouthPoliciesResponse(Long userId, List<Tag> tags, List<YouthPolicy> youthPolicyTags) {
+        this.userId = userId;
+        this.tags = tags;
+        this.youthPolicyTags = youthPolicyTags;
+    }
+
+}

--- a/src/main/java/org/project/soar/model/user/service/UserService.java
+++ b/src/main/java/org/project/soar/model/user/service/UserService.java
@@ -5,9 +5,9 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.project.soar.config.TokenProvider;
-import org.project.soar.model.comment.Comment;
 import org.project.soar.model.permission.repository.PermissionRepository;
 import org.project.soar.model.permission.service.PermissionService;
+import org.project.soar.model.tag.Tag;
 import org.project.soar.model.user.KakaoUser;
 import org.project.soar.model.user.RefreshToken;
 import org.project.soar.model.user.User;
@@ -16,8 +16,9 @@ import org.project.soar.model.user.repository.KakaoUserRepository;
 import org.project.soar.model.user.repository.RefreshTokenRepository;
 import org.project.soar.model.user.repository.UserRepository;
 import org.project.soar.model.usertag.repository.UserTagRepository;
-import org.project.soar.model.youthpolicy.UserYouthPolicy;
 import org.project.soar.model.youthpolicy.repository.UserYouthPolicyRepository;
+import org.project.soar.model.youthpolicy.YouthPolicy;
+import org.project.soar.model.youthpolicytag.repository.YouthPolicyTagRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -41,7 +42,7 @@ public class UserService {
     private final PermissionRepository permissionRepository;
     private final UserYouthPolicyRepository userYouthPolicyRepository;
     private final UserTagRepository userTagRepository;
-
+    private final YouthPolicyTagRepository youthPolicyTagRepository;
     private final Random random = new Random();
 
     @Transactional
@@ -397,5 +398,12 @@ public class UserService {
             }
         } while (!isValidPassword(password.toString())); // 규칙 만족할 때까지 반복
         return password.toString();
+    }
+
+    public MatchYouthPoliciesResponse getMatchPolicies(Long userId) {
+        List<Tag> tags =  userTagRepository.findAllTagByUserId(userId);
+        List<Long> tagIds = tags.stream().map(tag -> tag.getTagId()).collect(Collectors.toList());
+        List<YouthPolicy> youthPolicies = youthPolicyTagRepository.findByTagIds(tagIds);
+        return new MatchYouthPoliciesResponse(userId, tags, youthPolicies);
     }
 }

--- a/src/main/java/org/project/soar/model/youthpolicy/repository/YouthPolicyRepository.java
+++ b/src/main/java/org/project/soar/model/youthpolicy/repository/YouthPolicyRepository.java
@@ -232,5 +232,9 @@ public interface YouthPolicyRepository extends JpaRepository<YouthPolicy, String
     List<YouthPolicy> findTop2ByOrderByCreatedAtDesc();
 
     List<YouthPolicy> findTop5ByOrderByCreatedAtDesc();
+
+    List<YouthPolicy> findTop20ByOrderByCreatedAtDesc();
+
+    List<YouthPolicy> findTop10ByOrderByCreatedAtAsc();
 }
 

--- a/src/main/java/org/project/soar/model/youthpolicytag/controller/YouthPolicyTagController.java
+++ b/src/main/java/org/project/soar/model/youthpolicytag/controller/YouthPolicyTagController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.project.soar.global.api.ApiResponse;
+import org.project.soar.model.tag.dto.YouthPolicyTagsResponse;
 import org.project.soar.model.youthpolicytag.dto.FindYouthPolicyByTagResponse;
 import org.project.soar.model.youthpolicytag.dto.YouthPolicyTagResponse;
 import org.project.soar.model.youthpolicytag.service.YouthPolicyTagService;
@@ -26,9 +27,16 @@ public class YouthPolicyTagController {
     }
 
     @GetMapping("/tag")
-    @Operation(summary = "태그를 기준으로 정책 조회")
+    @Operation(summary = "하나의 태그로 정책 조회")
     public ResponseEntity<ApiResponse<FindYouthPolicyByTagResponse>> getYouthPolicyTagByTagId(@RequestParam("tagId") Long tagId) {
-        FindYouthPolicyByTagResponse result = youthPolicyTagService.getYouthPolicyTagByTagID(tagId);
+        FindYouthPolicyByTagResponse result = youthPolicyTagService.getYouthPolicyTagByTagId(tagId);
+        return ResponseEntity.ok(ApiResponse.createSuccess(result));
+    }
+
+    @GetMapping("/tags")
+    @Operation(summary = "여러 개의 태그로 정책 조회")
+    public ResponseEntity<ApiResponse<YouthPolicyTagsResponse>> getYouthPolicyTagByTagIds(@RequestParam("tagIds") List<Long> tagIds) {
+        YouthPolicyTagsResponse result = youthPolicyTagService.getAllYouthPolicyByTagIds(tagIds);
         return ResponseEntity.ok(ApiResponse.createSuccess(result));
     }
 

--- a/src/main/java/org/project/soar/model/youthpolicytag/repository/YouthPolicyTagRepository.java
+++ b/src/main/java/org/project/soar/model/youthpolicytag/repository/YouthPolicyTagRepository.java
@@ -16,4 +16,7 @@ public interface YouthPolicyTagRepository extends JpaRepository<YouthPolicyTag, 
     boolean existsByYouthPolicy(YouthPolicy youthPolicy);
     @Query("SELECT ypt.youthPolicy FROM YouthPolicyTag ypt WHERE ypt.tag.tagId = :tagId")
     List<YouthPolicy> findByTagId(@Param("tagId") Long tagId);
+
+    @Query("SELECT ypt.youthPolicy FROM YouthPolicyTag ypt WHERE ypt.tag.tagId IN :tagIds")
+    List<YouthPolicy> findByTagIds(@Param("tagIds") List<Long> tagIds);
 }

--- a/src/main/java/org/project/soar/model/youthpolicytag/service/YouthPolicyTagService.java
+++ b/src/main/java/org/project/soar/model/youthpolicytag/service/YouthPolicyTagService.java
@@ -1,5 +1,6 @@
 package org.project.soar.model.youthpolicytag.service;
 
+import org.project.soar.model.tag.dto.YouthPolicyTagsResponse;
 import org.project.soar.model.youthpolicytag.YouthPolicyTag;
 import org.project.soar.model.youthpolicytag.controller.YouthPolicyTagRequest;
 import org.project.soar.model.youthpolicytag.dto.FindYouthPolicyByTagResponse;
@@ -11,8 +12,7 @@ import java.util.List;
 public interface YouthPolicyTagService {
     List<YouthPolicyTagResponse> getAllYouthPolicyTag();
     YouthPolicyTag setYouthPolicyTag(YouthPolicyTagResponse youthPolicyTagResponse);
-
-    FindYouthPolicyByTagResponse getYouthPolicyTagByTagID(Long tagId);
-
+    FindYouthPolicyByTagResponse getYouthPolicyTagByTagId(Long tagId);
     List<YouthPolicyTagResponse> createYouthPolicyTag(YouthPolicyTagRequest youthPolicyTagRequest);
+    YouthPolicyTagsResponse getAllYouthPolicyByTagIds(List<Long> tagIds);
 }

--- a/src/main/java/org/project/soar/model/youthpolicytag/service/YouthPolicyTagServiceImpl.java
+++ b/src/main/java/org/project/soar/model/youthpolicytag/service/YouthPolicyTagServiceImpl.java
@@ -3,6 +3,7 @@ package org.project.soar.model.youthpolicytag.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.project.soar.model.tag.Tag;
+import org.project.soar.model.tag.dto.YouthPolicyTagsResponse;
 import org.project.soar.model.tag.service.TagService;
 import org.project.soar.model.youthpolicytag.YouthPolicyTag;
 import org.project.soar.model.youthpolicytag.controller.YouthPolicyTagRequest;
@@ -60,8 +61,9 @@ public class YouthPolicyTagServiceImpl implements YouthPolicyTagService{
         return newYouthPolicyTag;
 
     }
+
     @Override
-    public FindYouthPolicyByTagResponse getYouthPolicyTagByTagID(Long tagId) {
+    public FindYouthPolicyByTagResponse getYouthPolicyTagByTagId(Long tagId) {
         List<YouthPolicy> youthPolicies = youthPolicyTagRepository.findByTagId(tagId);
         youthPolicies.stream().map(youthPolicy -> youthPolicy.getPolicyId()).collect(Collectors.toList());
         return new FindYouthPolicyByTagResponse(
@@ -81,4 +83,12 @@ public class YouthPolicyTagServiceImpl implements YouthPolicyTagService{
             return new YouthPolicyTagResponse(result.getYouthPolicy().getPolicyId(), result.getYouthPolicy().getPolicyName(), result.getTag().getTagId(), result.getTag().getTagName());
         }).collect(Collectors.toList());
     }
+
+    @Override
+    public YouthPolicyTagsResponse getAllYouthPolicyByTagIds(List<Long> tagIds) {
+        List<Tag> tags = tagIds.stream().map(tagId -> tagRepository.findByTagId(tagId)).collect(Collectors.toList());
+        List<YouthPolicy> youthPolicies = youthPolicyTagRepository.findByTagIds(tagIds);
+        return new YouthPolicyTagsResponse(tags, youthPolicies);
+    }
+
 }


### PR DESCRIPTION
- feat : 선택한 여러 태그들을 모두 가지고 있는 정책들 가져오기
- feat : 사용자의 ID를 받아 그에 맞는 정책 return
- fix : jwt.yml과 연결 삭제
- chore : YouthPolicyRepository에 정책 열람 method 추가
